### PR TITLE
Change over Toolforge links to match new URL structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [hashtags-hub](https://tools.wmflabs.org/hashtags-hub)
+# [hashtags-hub](https://hashtags-hub.toolforge.org)
 
 A web service to get links to hashtag pages on different web platforms. The main purpose of this tool is to be used on Wikidata as the ['formatter URL' (P1630)](https://www.wikidata.org/wiki/Property:P1630) value of ['hashtag' (P2572)](https://www.wikidata.org/wiki/Property:P2572), without having to systematically link to a unique centralized platform, hashtags being, most of the time, not bound to a single platform.
 

--- a/server/templates/hashtag.js
+++ b/server/templates/hashtag.js
@@ -110,7 +110,7 @@ const codePlatforms = [
 ]
 
 const wikimediaSites = [
-  { name: 'Wikidata', formatter: 'https://tools.wmflabs.org/hub/P2572:$1?site=wikidata' },
-  { name: 'Wikipedia', formatter: 'https://tools.wmflabs.org/hub/P2572:$1?site=wikipedia' },
+  { name: 'Wikidata', formatter: 'https://hub.toolforge.org/P2572:$1?site=wikidata' },
+  { name: 'Wikipedia', formatter: 'https://hub.toolforge.org/P2572:$1?site=wikipedia' },
   { name: 'Wikimedia edit summaries', formatter: 'https://hashtags.wmflabs.org/?query=$1', article: 'in', icon: 'wm_summary_icon.png' },
 ]

--- a/server/templates/home.html
+++ b/server/templates/home.html
@@ -32,7 +32,7 @@
 
     <h2>Example</h2>
     <p>
-      <a href="/hashtags-hub/Wikidata">Find platforms' <span class="code">#Wikidata</span> pages</a>
+      <a href="/Wikidata">Find platforms' <span class="code">#Wikidata</span> pages</a>
     </p>
   </main>
   <footer>


### PR DESCRIPTION
The example link on the home page broke with the server move; the homepage in the README and the hub links still worked, but I changed them to avoid unnecessary redirects.