### PR TITLE
Add 'libre' tag to GitLab

### DIFF
--- a/server/templates/hashtag.js
+++ b/server/templates/hashtag.js
@@ -109,7 +109,7 @@ const audioPlatforms = [
 
 const codePlatforms = [
   { name: 'GitHub', formatter: 'https://github.com/topics/$1' },
-  { name: 'GitLab', formatter: 'https://gitlab.com/explore/projects/topics/$1' },
+  { name: 'GitLab', formatter: 'https://gitlab.com/explore/projects/topics/$1', tags: [ 'libre' ] }, 
 ]
 
 const wikimediaSites = [

--- a/server/templates/hashtag.js
+++ b/server/templates/hashtag.js
@@ -109,7 +109,7 @@ const audioPlatforms = [
 
 const codePlatforms = [
   { name: 'GitHub', formatter: 'https://github.com/topics/$1' },
-  { name: 'GitLab', formatter: 'https://gitlab.com/explore/projects/topics/$1', tags: [ 'libre' ] }, 
+  { name: 'GitLab', formatter: 'https://gitlab.com/explore/projects/topics/$1', tags: [ 'libre' ] },
 ]
 
 const wikimediaSites = [


### PR DESCRIPTION
Just realised this but it should have the tag as it's open source